### PR TITLE
Fix justification counts in monthly summary

### DIFF
--- a/backend/src/utils/resumeUtils.js
+++ b/backend/src/utils/resumeUtils.js
@@ -18,6 +18,8 @@ async function calcularResumoMensal(discordId, ano, mes) {
 
   let totalMinutos = 0;
   let extras = { util: 0, sabado: 0, domingo_feriado: 0 };
+  let pendentes = 0;
+  let aprovadas = 0;
 
   for (const reg of registros) {
     const minutos = extrairMinutosDeString(reg.total_horas);
@@ -28,6 +30,9 @@ async function calcularResumoMensal(discordId, ano, mes) {
     else extras.util += minutos;
 
     totalMinutos += minutos;
+
+    if (reg.justificativa?.status === "pendente") pendentes++;
+    if (reg.justificativa?.status === "aprovado") aprovadas++;
   }
 
   const diasUteis = await contarDiasUteisValidos(ano, mes, discordId);
@@ -49,23 +54,6 @@ async function calcularResumoMensal(discordId, ano, mes) {
   }
 
   const saldo = totalMinutos - metaMinutos;
-
-  let pendentes = 0;
-  let aprovadas = 0;
-
-  for (const reg of registros) {
-    const minutos = extrairMinutosDeString(reg.total_horas);
-    const tipo = await getTipoDeDia(reg.data);
-
-    if (tipo === "sabado") extras.sabado += minutos;
-    else if (tipo === "domingo" || tipo === "feriado") extras.domingo_feriado += minutos;
-    else extras.util += minutos;
-
-    totalMinutos += minutos;
-
-    if (reg.justificativa?.status === "pendente") pendentes++;
-    if (reg.justificativa?.status === "aprovada") aprovadas++;
-  }
 
   return {
     usuario: registros[0]?.usuario || discordId,


### PR DESCRIPTION
## Summary
- ensure approved justifications use the same status label
- avoid double counting of worked hours when computing monthly summaries

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c01447b88832b9b006a1e95ec9d26