### PR TITLE
Improve dark mode support

### DIFF
--- a/frontend/src/components/Auth/Login.jsx
+++ b/frontend/src/components/Auth/Login.jsx
@@ -3,10 +3,11 @@ import { signInWithEmailAndPassword, createUserWithEmailAndPassword } from "fire
 import { auth, db } from "../../config/firebaseConfig";
 import { useNavigate } from "react-router-dom";
 import { Input, Button, Card, Typography, message, Tabs, Form } from "antd";
-import { LockOutlined, MailOutlined } from "@ant-design/icons";
+import { LockOutlined, MailOutlined, BulbOutlined, BulbFilled } from "@ant-design/icons";
 import { setDoc, doc } from "firebase/firestore";
 import { useContext } from "react";
 import AuthContext from "../../context/AuthContext";
+import useDarkMode from "../../hooks/useDarkMode";
 
 const { Title, Text } = Typography;
 
@@ -15,6 +16,7 @@ const AuthPage = () => {
   const [activeTab, setActiveTab] = useState("login");
   const navigate = useNavigate();
   const { user, loading: authLoading } = useContext(AuthContext);
+  const [darkMode, setDarkMode] = useDarkMode();
 
   if (authLoading) {
     return <div>Carregando...</div>;
@@ -50,6 +52,13 @@ const AuthPage = () => {
   return (
     <div className="auth-container">
       <Card className="auth-card">
+        <button
+          onClick={() => setDarkMode(!darkMode)}
+          className="theme-toggle"
+          title="Alternar Tema"
+        >
+          {darkMode ? <BulbFilled /> : <BulbOutlined />}
+        </button>
         <Title level={2} className="auth-title">Bem-vindo</Title>
         <Text type="secondary">Acesse sua conta ou cadastre-se para continuar</Text>
 

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -8,8 +8,11 @@ import ProtectedLayout from "../components/layout/ProtectedLayout";
 import AuthPage from "../components/Auth/Login";
 import GoalsManager from "../components/Auth/GoalsManager";
 import ManageSpecialDates from "../components/Admin/ManageSpecialDates";
+import useDarkMode from "../hooks/useDarkMode";
 
 function App() {
+  // Apply the saved theme on initial load so every route respects the chosen mode
+  useDarkMode();
   return (
     <AuthProvider>
       <Router>

--- a/frontend/src/styles/_login.scss
+++ b/frontend/src/styles/_login.scss
@@ -15,6 +15,13 @@
   border-radius: 12px;
   background: #fff;
   text-align: center;
+  position: relative;
+
+  .theme-toggle {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
 }
 
 .auth-title {
@@ -38,4 +45,38 @@
 
 .auth-form .ant-btn {
   margin-top: 10px;
+}
+
+body.dark {
+  .auth-container {
+    background: var(--background-color);
+    color: var(--text-color);
+  }
+
+  .auth-card {
+    background: var(--card-bg);
+    color: var(--text-color);
+    box-shadow: none;
+    border: 1px solid var(--border-color);
+    .theme-toggle {
+      color: var(--text-color);
+    }
+  }
+
+  .ant-tabs-tab,
+  .ant-input,
+  .ant-input-password,
+  .ant-input-password input {
+    background-color: #2a2a2a;
+    color: var(--text-color);
+    border-color: var(--border-color);
+  }
+
+  .ant-input::placeholder {
+    color: #aaa;
+  }
+
+  .ant-tabs-tab-btn {
+    color: var(--text-color);
+  }
 }

--- a/frontend/src/styles/_records-table.scss
+++ b/frontend/src/styles/_records-table.scss
@@ -15,6 +15,7 @@
   -webkit-overflow-scrolling: touch;
   display: flex;
   flex-direction: column;
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 
   @media (max-width: 1400px) {
     width: 95vw;
@@ -78,11 +79,13 @@
     font-weight: bold;
     padding: 16px;
     text-transform: uppercase;
+    border-bottom: 1px solid $goepik-border-light;
   }
 
   .ant-table-tbody > tr > td {
     font-size: 14px;
     padding: 14px;
+    border-bottom: 1px solid $goepik-border-light;
   }
 
   @media (max-width: 768px) {
@@ -304,6 +307,7 @@ body.dark .table-container {
   color: var(--text-color);
   box-shadow: none;
   border-color: var(--border-color);
+  transition: background-color 0.3s, color 0.3s, border-color 0.3s;
 }
 
 body.dark .ant-table-thead > tr > th,
@@ -311,6 +315,7 @@ body.dark .ant-table-tbody > tr > td {
   background-color: var(--card-bg);
   color: var(--text-color);
   border-color: var(--border-color);
+  border-bottom: 1px solid var(--border-color);
 }
 
 body.dark .record-card {

--- a/frontend/src/styles/_sidebar-menu.scss
+++ b/frontend/src/styles/_sidebar-menu.scss
@@ -6,7 +6,7 @@
   border-right: 1px solid #e6e6e6;
   display: flex;
   flex-direction: column;
-  transition: width 0.3s ease;
+  transition: background-color 0.3s, border-color 0.3s, width 0.3s ease;
   position: sticky;
   top: 0;
   z-index: 1000;
@@ -46,7 +46,7 @@
       margin-bottom: 1rem;
 
       a, button {
-        text-decoration: none; 
+        text-decoration: none;
         display: flex;
         align-items: center;
         gap: 0.75rem;
@@ -58,7 +58,7 @@
         padding: 0.5rem 1rem;
         text-align: left;
         border-radius: 12px;
-        transition: all 0.2s ease;
+        transition: background-color 0.2s ease, color 0.2s ease;
 
         &:hover {
           background-color: #f0f0f0;

--- a/frontend/src/styles/_topbar.scss
+++ b/frontend/src/styles/_topbar.scss
@@ -6,6 +6,7 @@
   padding: 0 24px;
   height: 75px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.06);
+  transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   z-index: 10;
   position: fixed;
   width: 100%;
@@ -71,6 +72,7 @@
     cursor: pointer;
     padding: 4px 12px;
     border-bottom: 2px solid transparent;
+    transition: color 0.2s, border-color 0.2s;
 
     &:hover {
       color: #1677ff;
@@ -92,6 +94,7 @@
 body.dark .topbar {
   background-color: var(--sidebar-bg);
   box-shadow: none;
+  transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
 
   &__nav a,
   &__nav button,

--- a/frontend/src/styles/main.scss
+++ b/frontend/src/styles/main.scss
@@ -35,6 +35,7 @@ body {
   background-image: radial-gradient(rgba(0, 0, 0, 0.05) 1px, transparent 1px);
   background-size: 12px 12px;
   background-position: 0 0;
+  transition: background-color 0.3s, color 0.3s;
 
   @media (max-width: 576px) {
     background-size: 10px 10px;
@@ -61,6 +62,7 @@ body {
   max-width: 1400px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
   flex-grow: 1;
+  transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
 
   @media (max-width: 576px) {
     display: flex;
@@ -122,6 +124,7 @@ body.dark {
   cursor: pointer;
   margin-right: 16px;
   color: #555;
+  transition: color 0.3s;
 
   &:hover {
     color: #1677ff;
@@ -134,4 +137,5 @@ body.dark {
 
 body.dark .theme-toggle {
   color: #f0f0f0;
+  transition: color 0.3s;
 }


### PR DESCRIPTION
## Summary
- ensure dark mode class is applied on initial load
- add theme toggle on login page
- tweak login styles for dark mode
- add smooth transitions for sidebar, topbar and dashboard
- style table lines for dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685da72266c8832b9300f06a4378cb9c