### PR TITLE
Fix approval modal

### DIFF
--- a/frontend/src/components/Admin/Dashboard.jsx
+++ b/frontend/src/components/Admin/Dashboard.jsx
@@ -21,6 +21,7 @@ import { carregarRegistrosFiltrados, carregarResumoMensal } from "../../helper/u
 import DashboardGeneral from "./DashboardGeneral";
 import DashboardOverview from "./DashboardOverview";
 import PendingJustificationsModal from "./justification/PendingJustificationsModal";
+import { upsertJustificativa } from "../../services/justificativaService";
 
 dayjs.extend(isSameOrAfter);
 dayjs.extend(isSameOrBefore);


### PR DESCRIPTION
## Summary
- import upsertJustificativa in Dashboard to enable approval modal

## Testing
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686bb6a995d4832bae661aa849a64c4c